### PR TITLE
Fixed audio source issue + Some UI options added

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -91,6 +91,12 @@
 
     <entry name="quranReciterIndex" type="Int">
       <default>0</default> </entry>
+    <entry name="useDynamicFont" type="Bool">
+      <default>true</default>
+    </entry>
+    <entry name="showBackground" type="Bool">
+      <default>true</default>
+    </entry>
 
   </group>
   <group name="About">

--- a/contents/ui/configGeneral.qml
+++ b/contents/ui/configGeneral.qml
@@ -39,6 +39,8 @@ KCM.SimpleKCM {
     property alias cfg_notifications: notificationsCheck.checked
     property alias cfg_preNotificationMinutes: preNotificationSpinBox.value
     property alias cfg_playPreAdhanSound: preAdhanSoundCheck.checked
+    property alias cfg_useDynamicFont: dynamicFontCheck.checked
+    property alias cfg_showBackground: showBackgroundCheck.checked
 
     // Audio
     property alias cfg_adhanAudioPath: adhanPathField.text
@@ -176,6 +178,8 @@ KCM.SimpleKCM {
             model: ["English", "Arabic"]
         }
         CheckBox { id: hourFormatCheck; text: i18n("Use 12-hour format (AM/PM)"); Kirigami.FormData.label: i18n("Time Format:") }
+        CheckBox { id: dynamicFontCheck; text: i18n("Fit text to width"); Kirigami.FormData.label: i18n("Appearance:") }
+        CheckBox { id: showBackgroundCheck; text: i18n("Show background"); Kirigami.FormData.label: "" }
 
         CheckBox { id: notificationsCheck; text: i18n("Show notification on prayer time"); Kirigami.FormData.label: i18n("Alerts:") }
 

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -7,12 +7,15 @@ import org.kde.plasma.plasmoid
 import org.kde.notification
 import Qt.labs.settings
 import QtMultimedia
+import org.kde.plasma.core as PlasmaCore
 
 PlasmoidItem {
     id: root
 
     Layout.minimumWidth: Kirigami.Units.gridUnit * 7
     Layout.preferredWidth: Kirigami.Units.gridUnit * 7
+
+    Plasmoid.backgroundHints: (Plasmoid.configuration.showBackground === undefined || Plasmoid.configuration.showBackground) ? PlasmaCore.Types.StandardBackground : PlasmaCore.Types.NoBackground
 
     // =========================================================================
     // PROPERTIES & DATA
@@ -536,11 +539,17 @@ PlasmoidItem {
                     else return i18n("Time until next prayer: %1", root.timeUntilNextPrayer);
                 }
                 visible: root.timeUntilNextPrayer !== "" && root.timeUntilNextPrayer !== i18n("Prayer time!")
-                font.pointSize: Kirigami.Theme.smallFont.pointSize
+                
+                width: parent.width - (Kirigami.Units.largeSpacing * 2)
+                fontSizeMode: (Plasmoid.configuration.useDynamicFont === undefined || Plasmoid.configuration.useDynamicFont) ? Text.Fit : Text.FixedSize
+                minimumPixelSize: 10
+                font.pixelSize: (Plasmoid.configuration.useDynamicFont === undefined || Plasmoid.configuration.useDynamicFont) ? 72 : Kirigami.Theme.smallFont.pixelSize
+
                 font.weight: Font.Bold
                 opacity: 0.95
                 color: Kirigami.Theme.textColor
                 anchors.horizontalCenter: parent.horizontalCenter
+                horizontalAlignment: Text.AlignHCenter
             }
 
             PlasmaComponents.MenuSeparator {


### PR DESCRIPTION
Assalamualykum
I had an [issue](https://github.com/MazenMohamed203/salaatprayertime/issues/4) open for the issue with audio source switching while playing Quran audio clips, the latest fix did not help in my case, so I worked on a hotfix myself.
<details><summary>The actual issue cause</summary>
<p>
This issue was caused by two problems:

The valueChanged handler manually assigns quranReciterIndex and activeReciterIdentifier, breaking QML property bindings and causing the UI to desync from the configuration.
When fetching verse data, the callback checks for the current root.activeReciterIdentifier. If the user changes the reciter while a request is in progress, the response (containing the old reciter data) fails the check against the new identifier, causing the player to fail silently or stop.
</p>
</details> 
<details><summary>The solution overview</summary>
<p>
Add an onQuranReciterIndexChanged handler to root to manage side effects (clearing cache, fetching daily verse) when the index changes. This relies on the existing property binding property int quranReciterIndex: Plasmoid.configuration.quranReciterIndex || 0

Capture root.activeReciterIdentifier into a local variable targetReciter before making the request. Use targetReciter inside the xhr callback to find the audio data.
</p>
</details> 
I also added two minor UI options: 
1. background transparency, this makes it easier to add the widget in places where background is not needed
2. fit text to widget width for Time until next prayer, this is on be default, this is what I expect the behavior to be when stretching the widgets width.

hopefully I didn't disturb the plans for this project, but I figured I could help considering it's a minor issue