### PR TITLE
PR 2: Centralize prayer keys, add documentation, cleanup timers

### DIFF
--- a/contents/ui/CompactRepresentation.qml
+++ b/contents/ui/CompactRepresentation.qml
@@ -118,9 +118,11 @@ Item {
     }
 
     // --- Timers for Toggle Mode ---
+    readonly property int toggleDisplayDurationMs: 18000  // 18s showing prayer times
+    readonly property int toggleRemainingDurationMs: 8000  // 8s showing countdown
     Timer {
         id: toggleTimer
-        interval: 18000
+        interval: root.toggleDisplayDurationMs
         running: root.compactStyle === 2 || root.compactStyle === 4
         repeat: true
         onTriggered: {
@@ -131,7 +133,7 @@ Item {
 
     Timer {
         id: toggleReturnTimer
-        interval: 8000
+        interval: root.toggleRemainingDurationMs
         repeat: false
         onTriggered: {
             root.toggleViewIsPrayerTime = true;
@@ -284,5 +286,3 @@ Item {
         }
     }
 }
-
-

--- a/contents/ui/Constants.js
+++ b/contents/ui/Constants.js
@@ -1,5 +1,24 @@
 .pragma library
 
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+/** All prayer time keys used throughout the widget */
+const PRAYER_KEYS = ["Fajr", "Sunrise", "Dhuhr", "Asr", "Maghrib", "Isha"]
+
+/** Keys for optional extended times (Midnight & Last Third of the night) */
+const PRAYER_KEYS_EXTENDED = ["Midnight", "Lastthird"]
+
+/** All prayer keys including extended ones */
+const PRAYER_KEYS_ALL = PRAYER_KEYS.concat(PRAYER_KEYS_EXTENDED)
+
+/** Keys for which Adhan is played (prayer times only, not Sunrise/Midnight/Lastthird) */
+const PRAYER_KEYS_WITH_ADHAN = ["Fajr", "Dhuhr", "Asr", "Maghrib", "Isha"]
+
+/** Prayer key order for computing next prayer (used in highlightActivePrayer) */
+const PRAYER_KEYS_CHECK_ORDER = ["Isha", "Maghrib", "Asr", "Dhuhr", "Sunrise", "Fajr"]
+
 const surahData = [
     ["Al-Fatiha", "الفاتحة", 7], ["Al-Baqarah", "البقرة", 286], ["Al-Imran", "آل عمران", 200], ["An-Nisa", "النساء", 176],
     ["Al-Ma'idah", "المائدة", 120], ["Al-An'am", "الأنعام", 165], ["Al-A'raf", "الأعراف", 206], ["Al-Anfal", "الأنفال", 75],

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -534,7 +534,7 @@ PlasmoidItem {
 
             Repeater {
                 model: {
-                    let base = ["Fajr", "Sunrise", "Dhuhr", "Asr", "Maghrib", "Isha"];
+                    let base = Logic.PRAYER_KEYS;
                     if (Plasmoid.configuration.showMidnight) base.push("Midnight");
                     if (Plasmoid.configuration.showLastThird) base.push("Lastthird");
                     return base;
@@ -612,7 +612,7 @@ PlasmoidItem {
 
         console.log("Fetching Surah " + surahNum + " Verse " + ayahNum)
         let targetReciter = root.activeReciterIdentifier
-        
+
         let finalUrl = getPredictableAudioUrl(targetReciter, surahNum, ayahNum)
         if (ayahNum === 1 && surahNum !== 1 && surahNum !== 9) {
             let basmalahUrl = getPredictableAudioUrl(targetReciter, 1, 1);
@@ -701,8 +701,8 @@ PlasmoidItem {
             if (prayerKey === "Lastthird") return "Last Third";
             return prayerKey;
         }
-        const arabicPrayers = { 
-            "Fajr": "الفجر", "Sunrise": "الشروق", "Dhuhr": "الظهر", 
+        const arabicPrayers = {
+            "Fajr": "الفجر", "Sunrise": "الشروق", "Dhuhr": "الظهر",
             "Asr": "العصر", "Maghrib": "المغرب", "Isha": "العشاء",
             "Midnight": "منتصف الليل", "Lastthird": "الثلث الأخير"
         }
@@ -794,9 +794,8 @@ PlasmoidItem {
 
         const now = new Date();
         const notificationWindows = Plasmoid.configuration.preNotificationMinutes.split(",").map(s => parseInt(s.trim())).filter(n => !isNaN(n) && n > 0);
-        const prayerKeys = ["Fajr", "Dhuhr", "Asr", "Maghrib", "Isha"];
 
-        for (const prayerName of prayerKeys) {
+        for (const prayerName of Logic.PRAYER_KEYS_WITH_ADHAN) {
             const prayerTimeStr = currentTimingsToUse[prayerName];
             if (!prayerTimeStr || prayerTimeStr === "--:--") continue;
 
@@ -815,7 +814,6 @@ PlasmoidItem {
                         if (!root.preNotifiedPrayers[notificationKey]) {
                             var notification = notificationComponent.createObject(root);
 
-                            // Bilingual Pre-Adhan Logic
                             if (root.languageIndex === 1) {
                                 notification.title = i18n("باقي %1 دقائق على صلاة %2", minutesUntil, getPrayerName(root.languageIndex, prayerName));
                                 notification.text = i18n("تذكير بقرب موعد الأذان");
@@ -844,9 +842,8 @@ PlasmoidItem {
 
         const now = new Date();
         const notificationWindow = Plasmoid.configuration.postNotificationMinutes;
-        const prayerKeys = ["Fajr", "Dhuhr", "Asr", "Maghrib", "Isha"];
 
-        for (const prayerName of prayerKeys) {
+        for (const prayerName of Logic.PRAYER_KEYS_WITH_ADHAN) {
             const prayerTimeStr = currentTimingsToUse[prayerName];
             if (!prayerTimeStr || prayerTimeStr === "--:--") continue;
 
@@ -863,7 +860,6 @@ PlasmoidItem {
                 if (!root.postNotifiedPrayers[notificationKey]) {
                     var notification = notificationComponent.createObject(root);
 
-                    // Adjusted to focus on Iqamah and fixed pluralization
                     if (root.languageIndex === 1) {
                         notification.title = i18n("مرت %1 دقائق على صلاة %2", notificationWindow, getPrayerName(root.languageIndex, prayerName));
                         notification.text = i18n("تذكير: موعد الإقامة");
@@ -884,16 +880,20 @@ PlasmoidItem {
         }
     }
 
+    /**
+     * Determines which prayer time is currently active by comparing
+     * the current time against all prayer timings. Also triggers
+     * Adhan playback when transitioning to a new prayer.
+     */
     function highlightActivePrayer(currentTimingsToUse) {
         if (!currentTimingsToUse || !currentTimingsToUse.Fajr) {
             root.activePrayer = ""; return
         }
         var newActivePrayer = ""
         let now = new Date()
-        const prayerCheckOrder = ["Isha", "Maghrib", "Asr", "Dhuhr", "Sunrise", "Fajr"]
         let foundActive = false
 
-        for (const prayer of prayerCheckOrder) {
+        for (const prayer of Logic.PRAYER_KEYS_CHECK_ORDER) {
             if (currentTimingsToUse[prayer] && currentTimingsToUse[prayer] !== "--:--" && now >= parseTime(currentTimingsToUse[prayer])) {
                 newActivePrayer = prayer; foundActive = true; break
             }
@@ -951,6 +951,10 @@ PlasmoidItem {
                 return String(finalHours).padStart(2, '0') + ":" + String(finalMinutes).padStart(2, '0')
     }
 
+    /**
+     * Computes which prayer is next and how much time remains until it.
+     * Also handles day-boundary logic for Fajr (next day after Isha).
+     */
     function calculateNextPrayer() {
         const prayerData = root.displayPrayerTimes
         if (!prayerData || !prayerData.Fajr || prayerData.Fajr === "--:--") {
@@ -958,12 +962,11 @@ PlasmoidItem {
             root.nextPrayerNameForDisplay = i18n("N/A"); root.nextPrayerTimeForDisplay = "";
             return
         }
-        const prayerKeys = ["Fajr", "Dhuhr", "Asr", "Maghrib", "Isha"]
         const now = new Date()
         const currentTimeStr = ("0" + now.getHours()).slice(-2) + ":" + ("0" + now.getMinutes()).slice(-2)
 
         let nextPrayerKey = "", nextPrayerRawTime = ""
-        for (const key of prayerKeys) {
+        for (const key of Logic.PRAYER_KEYS_WITH_ADHAN) {
             if (prayerData[key] && prayerData[key] !== "--:--" && prayerData[key] > currentTimeStr) {
                 nextPrayerKey = key; nextPrayerRawTime = prayerData[key]; break
             }
@@ -992,8 +995,7 @@ PlasmoidItem {
             root.displayPrayerTimes = {defaultTimesStructure, apiGregorianDate: (root.times && root.times.apiGregorianDate) || defaultTimesStructure.apiGregorianDate }
         } else {
             let newDisplayTimes = {}
-            const prayerKeys = ["Fajr", "Sunrise", "Dhuhr", "Asr", "Maghrib", "Isha", "Midnight", "Lastthird"]
-            for (const key of prayerKeys) {
+            for (const key of Logic.PRAYER_KEYS_ALL) {
                 let offset = Plasmoid.configuration[key.toLowerCase() + "OffsetMinutes"] || 0
                 newDisplayTimes[key] = root.times[key] ? applyOffsetToTime(root.times[key], offset) : "--:--"
             }
@@ -1004,6 +1006,11 @@ PlasmoidItem {
         calculateNextPrayer()
     }
 
+    /**
+     * Processes raw Hijri date data from the API (or cache), applies
+     * the user-configured day offset, adjusts month/year boundaries,
+     * and updates the display and special Islamic date messages.
+     */
     function _setProcessedHijriData(hijriDataObject) {
         if (!hijriDataObject || !hijriDataObject.month) {
             root.hijriDateDisplay = i18n("Date unavailable")
@@ -1082,6 +1089,11 @@ PlasmoidItem {
                         root.specialIslamicDateMessage = message
     }
 
+    /**
+     * Fetches prayer times from the AlAdhan API, or falls back to offline calculation.
+     * Supports both coordinates-based and city-based lookups.
+     * Results are cached locally for offline use.
+     */
     function fetchTimes() {
         if (Plasmoid.configuration.forceOfflineMode) {
             loadFromCache();
@@ -1134,14 +1146,18 @@ PlasmoidItem {
         if (!root.times || !root.times.Fajr || !root.rawHijriDataFromApi) return
             let todayKey = getYYYYMMDD(new Date())
             let cleanTimings = {}
-            const prayerKeysToSave = ["Fajr", "Sunrise", "Dhuhr", "Asr", "Maghrib", "Isha", "Midnight", "Lastthird"]
-            prayerKeysToSave.forEach(function(pKey) { if (root.times[pKey]) cleanTimings[pKey] = root.times[pKey] })
+            Logic.PRAYER_KEYS_ALL.forEach(function(pKey) { if (root.times[pKey]) cleanTimings[pKey] = root.times[pKey] })
             if (Object.keys(cleanTimings).length === 0) return
                 let updatedCache = cachedData
                 updatedCache[todayKey] = { timings: cleanTimings, hijri: root.rawHijriDataFromApi }
                 cacheSettings.cacheData = JSON.stringify(updatedCache)
     }
 
+    /**
+     * Pre-fetches a full year of prayer times from AlAdhan API
+     * and caches them locally. Runs at most once every 30 days
+     * to ensure offline availability without excessive API calls.
+     */
     function update30DayCache() {
         const now = new Date()
         const cacheKey = "last_30day_update"
@@ -1177,8 +1193,7 @@ PlasmoidItem {
                                     const parts = dayData.date.gregorian.date.split('-'); if (parts.length !== 3) continue
                                     const dateKey = `${parts[2]}-${parts[1]}-${parts[0]}`
                                     const cleanTimings = {}
-                                    const prayerKeys = ["Fajr", "Sunrise", "Dhuhr", "Asr", "Maghrib", "Isha", "Midnight", "Lastthird"]
-                                    for (const pKey of prayerKeys) { if (dayData.timings[pKey]) cleanTimings[pKey] = dayData.timings[pKey] }
+                                    for (const pKey of Logic.PRAYER_KEYS_ALL) { if (dayData.timings[pKey]) cleanTimings[pKey] = dayData.timings[pKey] }
                                     if (Object.keys(cleanTimings).length > 0) updatedCache[dateKey] = { timings: cleanTimings, hijri: dayData.date.hijri }
                                 }
                             }
@@ -1194,6 +1209,11 @@ PlasmoidItem {
         saveTodayToCache()
     }
 
+    /**
+     * Loads prayer times from local cache. If not available and
+     * offline mode is enabled, falls back to astronomical calculation
+     * via OfflinePrayerCalc.js.
+     */
     function loadFromCache() {
         const todayKey = getYYYYMMDD(new Date()); let loaded = false
         if (!Plasmoid.configuration.forceOfflineMode && cachedData[todayKey]) {
@@ -1218,11 +1238,11 @@ PlasmoidItem {
                 let timeZoneOffset = -new Date().getTimezoneOffset() / 60
                 let method = Plasmoid.configuration.method !== undefined ? Plasmoid.configuration.method : 3
                 let school = Plasmoid.configuration.school !== undefined ? Plasmoid.configuration.school : 0
-                
+
                 root.times = OfflineCalc.getTimes(new Date(), lat, lng, timeZoneOffset, method, school)
                 root.times.apiGregorianDate = getFormattedDate(new Date())
                 processRawTimesAndApplyOffsets()
-                
+
                 let hAdj = Plasmoid.configuration.hijriOffset || 0
                 let hDate = OfflineCalc.getHijriDate(new Date(), hAdj)
                 root.currentHijriDay = hDate.day
@@ -1232,7 +1252,7 @@ PlasmoidItem {
                 let arMonths = ["محرم", "صفر", "ربيع الأول", "ربيع الآخر", "جمادى الأولى", "جمادى الآخرة", "رجب", "شعبان", "رمضان", "شوال", "ذو القعدة", "ذو الحجة"]
                 let enMonths = ["Muharram", "Safar", "Rabi Al-Awwal", "Rabi Al-Akhar", "Jumada Al-Awwal", "Jumada Al-Akhirah", "Rajab", "Shaban", "Ramadan", "Shawwal", "Dhu Al-Qidah", "Dhu Al-Hijjah"]
                 let monthName = root.languageIndex === 1 ? arMonths[hDate.month - 1] : enMonths[hDate.month - 1]
-                
+
                 root.hijriDateDisplay = hDate.day + " " + monthName + " " + hDate.year + " " + (root.languageIndex === 1 ? "هـ" : "AH")
                 updateSpecialIslamicDateMessage()
             } else {
@@ -1246,7 +1266,7 @@ PlasmoidItem {
     // =========================================================================
     // QURAN AUDIO PREDICTIVE ROUTING HELPERS
     // =========================================================================
-    
+
     function padZero(num) {
         var s = num + "";
         while (s.length < 3) s = "0" + s;
@@ -1363,13 +1383,13 @@ PlasmoidItem {
             return
         }
         let targetReciter = root.activeReciterIdentifier
-        
+
         let coords = globalAyahToSurahAyah(ayahNumber);
         let sNum = coords.surahNumber;
         let aNum = coords.ayahNumber;
-        
+
         let finalUrl = getPredictableAudioUrl(targetReciter, sNum, aNum);
-        
+
         if (aNum === 1 && sNum !== 1 && sNum !== 9) {
             root.storedVerseUrlForAfterBasmalah = finalUrl;
             root.nextTrackIsBasmalah = true;
@@ -1422,10 +1442,10 @@ PlasmoidItem {
                         if (data.city) Plasmoid.configuration.city = data.city;
                         if (data.country) {
                             Plasmoid.configuration.country = data.country;
-                            
+
                             let c = data.country.toLowerCase();
                             let methodIndex = 3; // Default to MWL
-                            
+
                             if (c.includes("egypt")) methodIndex = 5;
                             else if (c.includes("morocco")) methodIndex = 14;
                             else if (c.includes("pakistan") || c.includes("bangladesh") || c.includes("india") || c.includes("afghanistan")) methodIndex = 1;
@@ -1446,7 +1466,7 @@ PlasmoidItem {
                             else if (c.includes("indonesia")) methodIndex = 19;
                             else if (c.includes("portugal")) methodIndex = 20;
                             else if (c.includes("jordan")) methodIndex = 21;
-                            
+
                             Plasmoid.configuration.method = methodIndex;
                         }
                         if (data.lat && data.lon) {
@@ -1471,7 +1491,7 @@ PlasmoidItem {
                 if (key === "useCoordinates") root.useCoordinates = Plasmoid.configuration.useCoordinates || false
                 else if (key === "latitude") root.latitude = Plasmoid.configuration.latitude || ""
                 else if (key === "longitude") root.longitude = Plasmoid.configuration.longitude || ""
-                
+
                 // Invalidate cache and debounce the network fetch to avoid race condition and rate-limiting
                 cacheSettings.cacheData = "{}"
                 cacheSettings.lastCacheUpdate = 0


### PR DESCRIPTION
- Add PRAYER_KEYS, PRAYER_KEYS_ALL, PRAYER_KEYS_WITH_ADHAN, and PRAYER_KEYS_CHECK_ORDER constants to Constants.js
- Replace 7 hardcoded prayer key arrays across main.qml with shared constants
- Add JSDoc comments to 6 critical functions
- Replace magic timer intervals (18000/8000) with named readonly properties in CompactRepresentation.qml